### PR TITLE
fix: Use proper outdir when output_dir is specified

### DIFF
--- a/esbuild/private/esbuild.bzl
+++ b/esbuild/private/esbuild.bzl
@@ -230,7 +230,7 @@ def _esbuild_impl(ctx):
 
         # disable the log limit and show all logs
         args.update({
-            "outdir": js_out.path,
+            "outdir": js_out.short_path,
         })
     else:
         js_out = ctx.outputs.output


### PR DESCRIPTION
Testing with `BUILD.bazel` of:
```
load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")

esbuild(
    name = "bundle",
    entry_point = "index.ts",
    splitting = True,
)
```
and `index.ts` of:
```
console.log("Hello world");
```


Before change `bazel-bin/bundle`:
```
jesse@jessesaspectair test % ll bazel-bin/bundle
total 0
dr-xr-xr-x  2 jesse  wheel   64 21 Jun 17:09 .
drwxr-xr-x  6 jesse  wheel  192 21 Jun 17:09 ..
```

Post change `bazel-bin/bundle`:
```
jesse@jessesaspectair test % ll bazel-bin/bundle                      
total 16
dr-xr-xr-x  4 jesse  wheel  128 21 Jun 17:13 .
drwxr-xr-x  6 jesse  wheel  192 21 Jun 17:13 ..
-r-xr-xr-x  1 jesse  wheel   74 21 Jun 17:13 index.js
-r-xr-xr-x  1 jesse  wheel  103 21 Jun 17:13 index.js.map
```