### PR TITLE
fix: add onResolve plugin to enforce dependencies come from BAZEL_BIN

### DIFF
--- a/esbuild/private/esbuild.bzl
+++ b/esbuild/private/esbuild.bzl
@@ -204,7 +204,6 @@ def _esbuild_impl(ctx):
         "logLimit": 0,
         "metafile": ctx.attr.metafile,
         "platform": ctx.attr.platform,
-        "preserveSymlinks": True,
         "sourcesContent": ctx.attr.sources_content,
         "target": ctx.attr.target,
     })


### PR DESCRIPTION
Previously with `preserveSymlinks` set esbuild was unable to find transitive dependencies within the layout of node_modules that pnpm gives. This worked fine when using it under rules_nodejs, as that allowed us not to escape the sandbox and the layout was flat.

This allows us to avoid the user needing to hoist pretty much every runtime dependency, which could be a lot.
We can't just turn off `preserveSymlinks` though, otherwise esbuild will resolve dependencies elsewhere in our workspace, such as back to our source tree.

Building the following would now result in the error. Here we are intentionally commenting out `react-dom`
```
ts_project(
    name = "src",
    srcs = [
        "App.tsx",
        "index.tsx",
    ],
    declaration = True,
    supports_workers = False,
    transpiler = partial.make(
        swc_transpiler,
        swcrc = "//:swcrc",
    ),
    tsconfig = "//:tsconfig",
    deps = [
        "//:node_modules/react",
        #        "//:node_modules/react-dom",
    ],
)

esbuild(
    name = "bundle",
    srcs = [
        ":src",
    ],
    entry_point = "index.js",
)
```

```
$ bazel build //src:bundle --override_repository=aspect_rules_esbuild=/Users/matt/workspace/rules_esbuild
INFO: Analyzed target //src:bundle (77 packages loaded, 486 targets configured).
INFO: Found 1 target...
ERROR: /Users/matt/workspace/bazel-examples/ts_web_app/src/BUILD.bazel:27:8: Bundling Javascript src/index.js [esbuild] failed: (Exit 1): launcher.sh failed: error executing command bazel-out/darwin_arm64-opt-exec-2B5CBBC6/bin/external/esbuild_darwin-arm64/launcher.sh '--esbuild_args=src/bundle.args.json' '--metafile=src/bundle_metadata.json'

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
✘ [ERROR] [plugin Bazel Sandbox Guard] Failed to resolve import 'react-dom'. Ensure that it is a dependency of an upstream target

    ../../../../../../../../execroot/__main__/node_modules/.pnpm/react-dom@18.2.0_react@18.2.0/node_modules/react-dom/client.js:3:16:
      3 │ var m = require('react-dom');
        ╵                 ~~~~~~~~~~~
```

We could improve the error message, but that gets tricky when the import doesn't cleanly relate to a package name, eg removing `react` results in an import that's gone via a mapping in the `package.json` file (I guess?)

```
$ bazel build //src:bundle --override_repository=aspect_rules_esbuild=/Users/matt/workspace/rules_esbuild
INFO: Analyzed target //src:bundle (79 packages loaded, 494 targets configured).
INFO: Found 1 target...
ERROR: /Users/matt/workspace/bazel-examples/ts_web_app/src/BUILD.bazel:27:8: Bundling Javascript src/index.js [esbuild] failed: (Exit 1): launcher.sh failed: error executing command bazel-out/darwin_arm64-opt-exec-2B5CBBC6/bin/external/esbuild_darwin-arm64/launcher.sh '--esbuild_args=src/bundle.args.json' '--metafile=src/bundle_metadata.json'

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
✘ [ERROR] [plugin Bazel Sandbox Guard] Failed to resolve import './cjs/react.development.js'. Ensure that it is a dependency of an upstream target

    ../../../../../../../../execroot/__main__/node_modules/.pnpm/react@18.2.0/node_modules/react/index.js:6:27:
      6 │   module.exports = require('./cjs/react.development.js');
        ╵                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```