### PR TITLE
add npm-links sample

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,6 +21,7 @@ jobs:
         folder:
           - '.'
           - 'e2e/workspace'
+          - 'e2e/npm-links'
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 bazel-*
 .bazelrc.user
+node_modules

--- a/e2e/npm-links/BUILD.bazel
+++ b/e2e/npm-links/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@aspect_rules_js//npm:defs.bzl", "npm_link_package")
+load("@npm//:defs.bzl", "npm_link_all_packages")
+
+LIBRARIES = [
+    "lib",
+    "consumer",
+]
+
+[
+    npm_link_package(
+        name = "npm-link-example/%s" % lib,
+        src = "//%s:npm_package" % lib,
+    )
+    for lib in LIBRARIES
+]
+
+# Link npm packages
+npm_link_all_packages(name = "node_modules")

--- a/e2e/npm-links/WORKSPACE
+++ b/e2e/npm-links/WORKSPACE
@@ -1,0 +1,36 @@
+# Override http_archive for local testing
+local_repository(
+    name = "aspect_rules_esbuild",
+    path = "../..",
+)
+
+# Fetch the rules_esbuild dependencies.
+load("@aspect_rules_esbuild//esbuild:dependencies.bzl", "rules_esbuild_dependencies")
+
+rules_esbuild_dependencies()
+
+load("@rules_nodejs//nodejs:repositories.bzl", "DEFAULT_NODE_VERSION", "nodejs_register_toolchains")
+
+nodejs_register_toolchains(
+    name = "node",
+    node_version = DEFAULT_NODE_VERSION,
+)
+
+load("@aspect_rules_js//npm:npm_import.bzl", "npm_translate_lock")
+
+npm_translate_lock(
+    name = "npm",
+    pnpm_lock = "//:pnpm-lock.yaml",
+)
+
+# Register a toolchain containing esbuild npm package and native bindings
+load("@aspect_rules_esbuild//esbuild:repositories.bzl", "LATEST_VERSION", "esbuild_register_toolchains")
+
+esbuild_register_toolchains(
+    name = "esbuild",
+    esbuild_version = LATEST_VERSION,
+)
+
+load("@npm//:repositories.bzl", "npm_repositories")
+
+npm_repositories()

--- a/e2e/npm-links/consumer/BUILD.bazel
+++ b/e2e/npm-links/consumer/BUILD.bazel
@@ -1,0 +1,54 @@
+load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
+load("@aspect_rules_js//js:defs.bzl", "js_library")
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+
+# Source consuming that named library
+js_library(
+    name = "consumer",
+    srcs = ["src/consumer.js"],
+    deps = [
+        "//:node_modules/numeral",
+        "//:npm-link-example/lib",
+    ],
+)
+
+# Source consuming that named library
+js_library(
+    name = "spec",
+    srcs = ["src/spec.js"],
+    deps = [":consumer"],
+)
+
+# Run esbuild on the consuming code
+esbuild(
+    name = "bundle",
+    entry_point = "src/consumer.js",
+    output_dir = True,
+    deps = [":consumer"],
+)
+
+# Test that it builds
+build_test(
+    name = "test",
+    targets = [":bundle"],
+)
+
+# A named + linked library
+npm_package(
+    name = "npm_package",
+    srcs = [
+        "src/consumer.js",
+        ":_package_json",
+    ],
+    package = "@test-example/consumer",
+    visibility = ["//visibility:public"],
+)
+
+write_file(
+    name = "_package_json",
+    out = "package.json",
+    content = ["""{"name": "@test-example/consumer", "main": "./src/consumer.js"}"""],
+    visibility = ["//visibility:public"],
+)

--- a/e2e/npm-links/consumer/BUILD.bazel
+++ b/e2e/npm-links/consumer/BUILD.bazel
@@ -29,10 +29,24 @@ esbuild(
     deps = [":consumer"],
 )
 
+# Run esbuild on the consuming spec code
+esbuild(
+    name = "spec_bundle",
+    entry_point = "src/spec.js",
+    output_dir = True,
+    deps = [":spec"],
+)
+
 # Test that it builds
 build_test(
     name = "test",
     targets = [":bundle"],
+)
+
+# Test that spec builds
+build_test(
+    name = "test_spec",
+    targets = [":spec_bundle"],
 )
 
 # A named + linked library

--- a/e2e/npm-links/consumer/BUILD.bazel
+++ b/e2e/npm-links/consumer/BUILD.bazel
@@ -43,7 +43,9 @@ build_test(
     targets = [":bundle"],
 )
 
-# Test that spec builds
+# The spec file import the in-direct dependency lib
+# through consumer.
+# Test that spec bundle should also build
 build_test(
     name = "test_spec",
     targets = [":spec_bundle"],

--- a/e2e/npm-links/consumer/src/consumer.js
+++ b/e2e/npm-links/consumer/src/consumer.js
@@ -1,0 +1,6 @@
+import { ANSWER } from '@test-example/lib'
+import numeral from 'numeral'
+
+export function getAnswer() {
+  return numeral(ANSWER).format('0,0')
+}

--- a/e2e/npm-links/consumer/src/spec.js
+++ b/e2e/npm-links/consumer/src/spec.js
@@ -1,3 +1,5 @@
 import { getAnswer } from './consumer'
+// import from in-direct named library
+import { ANSWER } from '@test-example/lib'
 
-console.log(getAnswer())
+console.log(getAnswer(), ANSWER)

--- a/e2e/npm-links/consumer/src/spec.js
+++ b/e2e/npm-links/consumer/src/spec.js
@@ -1,0 +1,3 @@
+import { getAnswer } from './consumer'
+
+console.log(getAnswer())

--- a/e2e/npm-links/lib/BUILD.bazel
+++ b/e2e/npm-links/lib/BUILD.bazel
@@ -1,0 +1,20 @@
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+
+# A named + linked library
+npm_package(
+    name = "npm_package",
+    srcs = [
+        "src/lib.js",
+        ":_package_json",
+    ],
+    package = "@test-example/lib",
+    visibility = ["//visibility:public"],
+)
+
+write_file(
+    name = "_package_json",
+    out = "package.json",
+    content = ["""{"name": "@test-example/lib", "main": "./src/lib.js"}"""],
+    visibility = ["//visibility:public"],
+)

--- a/e2e/npm-links/lib/src/lib.js
+++ b/e2e/npm-links/lib/src/lib.js
@@ -1,0 +1,1 @@
+export const ANSWER = 42

--- a/e2e/npm-links/main.js
+++ b/e2e/npm-links/main.js
@@ -1,0 +1,3 @@
+import { getAnswer } from '@test-example/consumer'
+
+console.log(getAnswer())

--- a/e2e/npm-links/package.json
+++ b/e2e/npm-links/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "numeral": "^2.0.6"
+  }
+}

--- a/e2e/npm-links/pnpm-lock.yaml
+++ b/e2e/npm-links/pnpm-lock.yaml
@@ -1,0 +1,13 @@
+lockfileVersion: 5.4
+
+specifiers:
+  numeral: ^2.0.6
+
+dependencies:
+  numeral: 2.0.6
+
+packages:
+
+  /numeral/2.0.6:
+    resolution: {integrity: sha512-qaKRmtYPZ5qdw4jWJD6bxEf1FJEqllJrwxCLIm0sQU/A7v2/czigzOb+C2uSiFsa9lBUzeH7M1oK+Q+OLxL3kA==}
+    dev: false


### PR DESCRIPTION
Add `npm-links` sample to describe how to use `esbuild` rule with `npm_link_package` rule. The sample is based on @jbedard 's sample https://github.com/jbedard/rules_esbuild/tree/npm-link-package/e2e/npm-links