### PR TITLE
fix: don't preserve symlinks so we can resolve npm deps in the symlinked node_modules tree

### DIFF
--- a/esbuild/private/esbuild.bzl
+++ b/esbuild/private/esbuild.bzl
@@ -203,7 +203,13 @@ def _esbuild_impl(ctx):
         "logLimit": 0,
         "metafile": ctx.attr.metafile,
         "platform": ctx.attr.platform,
-        "preserveSymlinks": True,
+        # Don't preserve symlinks since doing so breaks node_modules resolution
+        # in the pnpm-style symlinked node_modules structure.
+        # See https://pnpm.io/symlinked-node-modules-structure.
+        # NB: esbuild will currently leave the sandbox and end up in the output
+        # tree until symlink guards are created to prevent this.
+        # See https://github.com/aspect-build/rules_esbuild/pull/32.
+        "preserveSymlinks": False,
         "sourcesContent": ctx.attr.sources_content,
         "target": ctx.attr.target,
     })

--- a/examples/banner/BUILD.bazel
+++ b/examples/banner/BUILD.bazel
@@ -33,11 +33,26 @@ esbuild(
     entry_point = "main.js",
 )
 
+# Make sed replacements for consistency on different platform
+[
+    genrule(
+        name = "sed_{}".format(basename.replace(".", "_")),
+        srcs = [":{}".format(basename)],
+        outs = ["sed_{}".format(basename)],
+        cmd = "sed \"s/\\/\\/ .*examples\\//\\/\\/ examples\\//\" $(execpath :{}) > $@".format(basename),
+    )
+    for basename in [
+        "banner_newline.js",
+        "banner_spaces.js",
+        "banner_quotes.js",
+    ]
+]
+
 write_source_files(
     name = "assertions",
     files = {
-        "newline.expected": "banner_newline.js",
-        "spaces.expected": "banner_spaces.js",
-        "quotes.expected": "banner_quotes.js",
+        "newline.expected": "sed_banner_newline.js",
+        "spaces.expected": "sed_banner_spaces.js",
+        "quotes.expected": "sed_banner_quotes.js",
     },
 )

--- a/examples/css/BUILD.bazel
+++ b/examples/css/BUILD.bazel
@@ -16,10 +16,25 @@ esbuild(
     output_css = "with_css.css",
 )
 
+# Make sed replacements for consistency on different platform
+genrule(
+    name = "sed_with_css_js",
+    srcs = [":with_css.js"],
+    outs = ["sed_with_css.js"],
+    cmd = "sed \"s/\\/\\/ .*examples\\//\\/\\/ examples\\//\" $(execpath :with_css.js) > $@",
+)
+
+genrule(
+    name = "sed_with_css_css",
+    srcs = [":with_css.css"],
+    outs = ["sed_with_css.css"],
+    cmd = "sed \"s/\\/\\* .*examples\\//\\/\\* examples\\//\" $(execpath :with_css.css) > $@",
+)
+
 write_source_files(
     name = "assertions",
     files = {
-        "css.expected": "with_css.css",
-        "js.expected": "with_css.js",
+        "css.expected": "sed_with_css.css",
+        "js.expected": "sed_with_css.js",
     },
 )


### PR DESCRIPTION
Don't preserve symlinks since doing so breaks node_modules resolution in the pnpm-style symlinked node_modules structure. See https://pnpm.io/symlinked-node-modules-structure.

NB: esbuild will currently leave the sandbox and end up in the output tree until symlink guards are created to prevent this. See https://github.com/aspect-build/rules_esbuild/pull/32.