### PR TITLE
chore: mirror latest esbuild version

### DIFF
--- a/esbuild/private/versions.bzl
+++ b/esbuild/private/versions.bzl
@@ -51,4 +51,12 @@ TOOL_VERSIONS = {
         "linux-arm64": "sha512-alEMGU4Z+d17U7KQQw2IV8tQycO6T+rOrgW8OS22Ua25x6kHxoG6Ngry6Aq6uranC+pNWNMB6aHFPh7aTQdORQ==",
         "windows-64": "sha512-Et6htEfGycjDrtqb2ng6nT+baesZPYQIW+HUEHK4D1ncggNrDNk3yoboYQ5KtiVrw/JaDMNttz8rrPubV/fvPQ==",
     },
+    "0.16.7": {
+        "npm": "sha512-P6OBFYFSQOGzfApqCeYKqfKRRbCIRsdppTXFo4aAvtiW3o8TTyiIplBvHJI171saPAiy3WlawJHCveJVIOIx1A==",
+        "darwin-x64": "sha512-duterlv3tit3HI9vhzMWnSVaB1B6YsXpFq1Ntd6Fou82BB1l4tucYy3FI9dHv3tvtDuS0NiGf/k6XsdBqPZ01w==",
+        "darwin-arm64": "sha512-VUb9GK23z8jkosHU9yJNUgQpsfJn+7ZyBm6adi2Ec5/U241eR1tAn82QicnUzaFDaffeixiHwikjmnec/YXEZg==",
+        "linux-x64": "sha512-xi/tbqCqvPIzU+zJVyrpz12xqciTAPMi2fXEWGnapZymoGhuL2GIWIRXg4O2v5BXaYA5TSaiKYE14L0QhUTuQg==",
+        "linux-arm64": "sha512-2wv0xYDskk2+MzIm/AEprDip39a23Chptc4mL7hsHg26P0gD8RUhzmDu0KCH2vMThUI1sChXXoK9uH0KYQKaDg==",
+        "win32-x64": "sha512-QaQ8IH0JLacfGf5cf0HCCPnQuCTd/dAI257vXBgb/cccKGbH/6pVtI1gwhdAQ0Y48QSpTIFrh9etVyNdZY+zzw==",
+    },
 }

--- a/scripts/mirror_release.sh
+++ b/scripts/mirror_release.sh
@@ -6,8 +6,8 @@ set -o errexit
 
 echo "    $(curl --silent "https://registry.npmjs.org/esbuild/latest" | jq ".version"): {"
 echo "        \"npm\": $(curl --silent "https://registry.npmjs.org/esbuild/latest" | jq ".dist.integrity"),"
-for pkg in darwin-{,arm}64 linux-{,arm}64 windows-64; do
-    echo "        \"$pkg\": $(curl --silent "https://registry.npmjs.org/esbuild-${pkg}/latest" | jq ".dist.integrity"),"
+for pkg in darwin-{x,arm}64 linux-{x,arm}64 win32-x64; do
+    echo "        \"$pkg\": $(curl --silent "https://registry.npmjs.org/@esbuild/${pkg}/latest" | jq ".dist.integrity"),"
 done
 echo "    },"
 echo


### PR DESCRIPTION
They changed the platform naming and URL structure so now we have to be conditional on the version in some spots