### PR TITLE
docs: note args --> config migration

### DIFF
--- a/esbuild/private/esbuild.bzl
+++ b/esbuild/private/esbuild.bzl
@@ -159,7 +159,7 @@ See https://esbuild.github.io/api/#target for more details
     "config": attr.label(
         mandatory = False,
         allow_single_file = True,
-        doc = """Configuration file used for esbuild. Note that options set in this file may get overwritten.
+        doc = """Configuration file used for esbuild. Note that options set in this file may get overwritten. If you formally used `args` from `@bazel/esbuild`, replace it with this attribute.
         TODO: show how to write a config file that depends on plugins, similar to the esbuild_config macro in rules_nodejs.
     """,
     ),

--- a/esbuild/private/esbuild.bzl
+++ b/esbuild/private/esbuild.bzl
@@ -159,7 +159,7 @@ See https://esbuild.github.io/api/#target for more details
     "config": attr.label(
         mandatory = False,
         allow_single_file = True,
-        doc = """Configuration file used for esbuild. Note that options set in this file may get overwritten. If you formally used `args` from `@bazel/esbuild`, replace it with this attribute.
+        doc = """Configuration file used for esbuild. Note that options set in this file may get overwritten. If you formerly used `args` from rules_nodejs' npm package `@bazel/esbuild`, replace it with this attribute.
         TODO: show how to write a config file that depends on plugins, similar to the esbuild_config macro in rules_nodejs.
     """,
     ),


### PR DESCRIPTION
This ensures that folks know that `config` is the replacement for `args` when coming from `@bazel/esbuild`. This is an issue I hit, see this discussion in slack https://bazelbuild.slack.com/archives/CEZUUKQ6P/p1675462695407799?thread_ts=1674525810.470589&cid=CEZUUKQ6P

CC @mattem @gregmagolan 