### PR TITLE
fix: don't ignore tsconfig field on user config

### DIFF
--- a/esbuild/private/launcher.js
+++ b/esbuild/private/launcher.js
@@ -57,7 +57,6 @@ async function processConfigFile(configFilePath, existingArgs = {}) {
     'preserveSymlinks',
     'sourcemap',
     'splitting',
-    'tsconfig',
   ]
 
   const MERGE_CONFIG_KEYS = ['define']
@@ -121,8 +120,8 @@ async function runOneBuild(args, userArgsFilePath, configFilePath) {
   try {
     const result = await esbuild.build(args)
     if (result.metafile) {
-      const metafile = getFlag('--metafile');
-      writeFileSync(metafile, JSON.stringify(result.metafile));
+      const metafile = getFlag('--metafile')
+      writeFileSync(metafile, JSON.stringify(result.metafile))
     }
   } catch (e) {
     console.error(e)


### PR DESCRIPTION
Looks like tsconfig was set in the old rules_nodejs [@bazel/esbuild](https://github.com/bazelbuild/rules_nodejs/blob/c18bc5f4208764fcdaa160f88d072bf33fef53b2/packages/esbuild/esbuild.bzl#L134) version of this rule (for path mappings) but it is no longer load bearing in rules_esbuild.

See https://bazelbuild.slack.com/archives/CEZUUKQ6P/p1678478456514209 for more context.