### PR TITLE
chore: bump skylib to latest

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -2,7 +2,7 @@ load("@bazel_gazelle//:def.bzl", "gazelle", "gazelle_binary")
 
 gazelle_binary(
     name = "gazelle_bin",
-    languages = ["@bazel_skylib//gazelle/bzl"],
+    languages = ["@bazel_skylib_gazelle_plugin//bzl"],
 )
 
 #gazelle:exclude internal_deps.bzl

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,7 +6,8 @@ module(
     version = "0.0.0",
 )
 
-bazel_dep(name = "bazel_skylib", version = "1.3.0")
+bazel_dep(name = "bazel_skylib", version = "1.4.1")
+bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.4.1", dev_dependency = True)
 bazel_dep(name = "aspect_bazel_lib", version = "1.27.2")
 bazel_dep(name = "aspect_rules_js", version = "1.19.0")
 bazel_dep(name = "rules_nodejs", version = "5.5.3")

--- a/esbuild/dependencies.bzl
+++ b/esbuild/dependencies.bzl
@@ -8,8 +8,11 @@ load("//esbuild/private:maybe.bzl", http_archive = "maybe_http_archive")
 def rules_esbuild_dependencies():
     http_archive(
         name = "bazel_skylib",
-        sha256 = "74d544d96f4a5bb630d465ca8bbcfe231e3594e5aae57e1edbf17a6eb3ca2506",
-        urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.3.0/bazel-skylib-1.3.0.tar.gz"],
+        sha256 = "b8a1527901774180afc798aeb28c4634bdccf19c4d98e7bdd1ce79d1fe9aaad7",
+        urls = [
+            "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.4.1/bazel-skylib-1.4.1.tar.gz",
+            "https://github.com/bazelbuild/bazel-skylib/releases/download/1.4.1/bazel-skylib-1.4.1.tar.gz",
+        ],
     )
 
     http_archive(

--- a/internal_deps.bzl
+++ b/internal_deps.bzl
@@ -21,14 +21,13 @@ def rules_esbuild_internal_deps():
         urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.28.0/bazel-gazelle-v0.28.0.tar.gz"],
     )
 
-    # Override bazel_skylib distribution to fetch sources instead
-    # so that the gazelle extension is included
-    # see https://github.com/bazelbuild/bazel-skylib/issues/250
     http_archive(
-        name = "bazel_skylib",
-        sha256 = "3b620033ca48fcd6f5ef2ac85e0f6ec5639605fa2f627968490e52fc91a9932f",
-        strip_prefix = "bazel-skylib-1.3.0",
-        urls = ["https://github.com/bazelbuild/bazel-skylib/archive/refs/tags/1.3.0.tar.gz"],
+        name = "bazel_skylib_gazelle_plugin",
+        sha256 = "0a466b61f331585f06ecdbbf2480b9edf70e067a53f261e0596acd573a7d2dc3",
+        urls = [
+            "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.4.1/bazel-skylib-gazelle-plugin-1.4.1.tar.gz",
+            "https://github.com/bazelbuild/bazel-skylib/releases/download/1.4.1/bazel-skylib-gazelle-plugin-1.4.1.tar.gz",
+        ],
     )
 
     http_archive(


### PR DESCRIPTION
The gazelle plugin is now a separate module