### PR TITLE
chore: fix link esbuild macro docstring

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -12,7 +12,7 @@ esbuild(<a href="#esbuild-name">name</a>, <a href="#esbuild-output_dir">output_d
 
 esbuild helper macro around the `esbuild_bundle` rule
 
-For a full list of attributes, see the [`esbuild_bundle`]() rule
+For a full list of attributes, see the [`esbuild_bundle`](./esbuild.md) rule
 
 
 **PARAMETERS**

--- a/esbuild/defs.bzl
+++ b/esbuild/defs.bzl
@@ -7,7 +7,7 @@ load("//esbuild/private:esbuild.bzl", _esbuild = "esbuild_bundle")
 def esbuild(name, output_dir = False, splitting = False, config = None, **kwargs):
     """esbuild helper macro around the `esbuild_bundle` rule
 
-    For a full list of attributes, see the [`esbuild_bundle`]() rule
+    For a full list of attributes, see the [`esbuild_bundle`](./esbuild.md) rule
 
     Args:
         name: The name used for this rule and output files


### PR DESCRIPTION
This is another one that has to keep getting fixed manually after docsite generation