### PR TITLE
fix: rename LATEST_VERSION to LATEST_ESBUILD_VERSION

### DIFF
--- a/e2e/npm-links/WORKSPACE
+++ b/e2e/npm-links/WORKSPACE
@@ -24,11 +24,11 @@ npm_translate_lock(
 )
 
 # Register a toolchain containing esbuild npm package and native bindings
-load("@aspect_rules_esbuild//esbuild:repositories.bzl", "LATEST_VERSION", "esbuild_register_toolchains")
+load("@aspect_rules_esbuild//esbuild:repositories.bzl", "LATEST_ESBUILD_VERSION", "esbuild_register_toolchains")
 
 esbuild_register_toolchains(
     name = "esbuild",
-    esbuild_version = LATEST_VERSION,
+    esbuild_version = LATEST_ESBUILD_VERSION,
 )
 
 load("@npm//:repositories.bzl", "npm_repositories")

--- a/e2e/smoke/WORKSPACE.bazel
+++ b/e2e/smoke/WORKSPACE.bazel
@@ -28,9 +28,9 @@ nodejs_register_toolchains(
 )
 
 # Register a toolchain containing esbuild npm package and native bindings
-load("@aspect_rules_esbuild//esbuild:repositories.bzl", "LATEST_VERSION", "esbuild_register_toolchains")
+load("@aspect_rules_esbuild//esbuild:repositories.bzl", "LATEST_ESBUILD_VERSION", "esbuild_register_toolchains")
 
 esbuild_register_toolchains(
     name = "esbuild",
-    esbuild_version = LATEST_VERSION,
+    esbuild_version = LATEST_ESBUILD_VERSION,
 )

--- a/e2e/sourcemaps/WORKSPACE
+++ b/e2e/sourcemaps/WORKSPACE
@@ -28,9 +28,9 @@ nodejs_register_toolchains(
 )
 
 # Register a toolchain containing esbuild npm package and native bindings
-load("@aspect_rules_esbuild//esbuild:repositories.bzl", "LATEST_VERSION", "esbuild_register_toolchains")
+load("@aspect_rules_esbuild//esbuild:repositories.bzl", "LATEST_ESBUILD_VERSION", "esbuild_register_toolchains")
 
 esbuild_register_toolchains(
     name = "esbuild",
-    esbuild_version = LATEST_VERSION,
+    esbuild_version = LATEST_ESBUILD_VERSION,
 )

--- a/esbuild/repositories.bzl
+++ b/esbuild/repositories.bzl
@@ -9,7 +9,7 @@ load("@bazel_skylib//lib:versions.bzl", "versions")
 load("//esbuild/private:toolchains_repo.bzl", "get_platforms", "toolchains_repo")
 load("//esbuild/private:versions.bzl", "TOOL_VERSIONS")
 
-LATEST_VERSION = TOOL_VERSIONS.keys()[-1]
+LATEST_ESBUILD_VERSION = TOOL_VERSIONS.keys()[-1]
 
 _DOC = "Fetch external tools needed for esbuild toolchain"
 _ATTRS = {


### PR DESCRIPTION
See https://github.com/aspect-build/rules_js/issues/817

BREAKING CHANGE: rename LATEST_VERSION to LATEST_ESBUILD_VERSION