### PR TITLE
fix: correct mapping to earlier esbuild releases

### DIFF
--- a/esbuild/private/toolchains_repo.bzl
+++ b/esbuild/private/toolchains_repo.bzl
@@ -54,14 +54,16 @@ _PLATFORMS = {
     ),
 }
 
-# v0.16.0 renamed the artifacts.
-# See release notes: https://github.com/evanw/esbuild/releases/tag/v0.16.0
-# These names work for releases before that.
 def get_platforms(version):
+    # The map above uses the "modern" artifact names
     if versions.is_at_least("0.16.0", version):
         return _PLATFORMS
+    # v0.16.0 renamed the artifacts.
+    # See release notes: https://github.com/evanw/esbuild/releases/tag/v0.16.0
+    # We have to transform the artifact names back to what they used to be.
     return {
-        k.replace("windows", "win32"): v
+        # reverse esbuild-windows-64 => @esbuild/win32-x64
+        k.replace("win32", "windows").replace("-x64", "-64") : v
         for k, v in _PLATFORMS.items()
     }
 

--- a/esbuild/private/toolchains_repo.bzl
+++ b/esbuild/private/toolchains_repo.bzl
@@ -58,12 +58,13 @@ def get_platforms(version):
     # The map above uses the "modern" artifact names
     if versions.is_at_least("0.16.0", version):
         return _PLATFORMS
+
     # v0.16.0 renamed the artifacts.
     # See release notes: https://github.com/evanw/esbuild/releases/tag/v0.16.0
     # We have to transform the artifact names back to what they used to be.
     return {
         # reverse esbuild-windows-64 => @esbuild/win32-x64
-        k.replace("win32", "windows").replace("-x64", "-64") : v
+        k.replace("win32", "windows").replace("-x64", "-64"): v
         for k, v in _PLATFORMS.items()
     }
 


### PR DESCRIPTION
I think @gregmagolan introduced a mistake in https://github.com/aspect-build/rules_esbuild/commit/abf0528384474f3b59733594e1f644b214c2a0ff#diff-31aeb5f9afff8dfdbee6cfca655d03053a3ffaf8857a1774f620b5e61daaa3a9L64-R64 and we don't have any CI testing for use of older versions of esbuild. I did this again from reasoning based on first-principles about what mapping we need to do here.

### Type of change

- Bug fix (change which fixes an issue)

### Test plan

- Covered by existing test cases
With this branch named to trigger tests