### PR TITLE
fix: allow root repositories to override esbuild toolchain version under bzlmod

### DIFF
--- a/esbuild/extensions.bzl
+++ b/esbuild/extensions.bzl
@@ -1,9 +1,12 @@
 "extensions for bzlmod"
 
-load(":repositories.bzl", "esbuild_register_toolchains")
+load(":repositories.bzl", "DEFAULT_ESBUILD_REPOSITORY", "esbuild_register_toolchains")
 
 esbuild_toolchain = tag_class(attrs = {
-    "name": attr.string(doc = "Base name for generated repositories"),
+    "name": attr.string(
+        doc = "Base name for generated repositories",
+        default = DEFAULT_ESBUILD_REPOSITORY,
+    ),
     "esbuild_version": attr.string(doc = "Explicit version of esbuild."),
     # TODO: support this variant
     # "esbuild_version_from": attr.string(doc = "Location of package.json which may have a version for @esbuild/core."),
@@ -13,7 +16,14 @@ def _toolchain_extension(module_ctx):
     registrations = {}
     for mod in module_ctx.modules:
         for toolchain in mod.tags.toolchain:
+            if toolchain.name != DEFAULT_ESBUILD_REPOSITORY and not mod.is_root:
+                fail("Only the root module may provide a name for the esbuild toolchain.")
+
             if toolchain.name in registrations.keys():
+                if toolchain.name == DEFAULT_ESBUILD_REPOSITORY:
+                    # Prioritize the root-most registration of the default esbuild toolchain version and
+                    # ignore any further registrations (modules are processed breadth-first)
+                    continue
                 if toolchain.esbuild_version == registrations[toolchain.name]:
                     # No problem to register a matching toolchain twice
                     continue

--- a/esbuild/repositories.bzl
+++ b/esbuild/repositories.bzl
@@ -11,6 +11,10 @@ load("//esbuild/private:versions.bzl", "TOOL_VERSIONS")
 
 LATEST_ESBUILD_VERSION = TOOL_VERSIONS.keys()[-1]
 
+# Default base name for esbuild toolchain repositories
+# created by the module extension
+DEFAULT_ESBUILD_REPOSITORY = "esbuild"
+
 _DOC = "Fetch external tools needed for esbuild toolchain"
 _ATTRS = {
     "esbuild_version": attr.string(mandatory = True, values = TOOL_VERSIONS.keys()),


### PR DESCRIPTION
Fixes the problem where overriding the default esbuild version in MODULE.bazel results in the error `Multiple conflicting toolchains declared for name esbuild`.

The solution is an adapted copy of @kormide's [fix to a similar problem under rules_nodejs](https://github.com/bazelbuild/rules_nodejs/pull/3626).
