### PR TITLE
chore: remove Go

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,17 +1,6 @@
-load("@bazel_gazelle//:def.bzl", "gazelle", "gazelle_binary")
 load("@buildifier_prebuilt//:rules.bzl", "buildifier")
 
-gazelle_binary(
-    name = "gazelle_bin",
-    languages = ["@bazel_skylib_gazelle_plugin//bzl"],
-)
-
 #gazelle:exclude internal_deps.bzl
-gazelle(
-    name = "gazelle",
-    gazelle = "gazelle_bin",
-)
-
 buildifier(
     name = "buildifier",
     exclude_patterns = ["./.git/*"],

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ Otherwise later tooling on CI may yell at you about formatting/linting violation
 
 Some targets are generated from sources.
 Currently this is just the `bzl_library` targets.
-Run `bazel run //:gazelle` to keep them up-to-date.
+Run `aspect configure` to keep them up-to-date.
 
 ## Using this as a development dependency of other rules
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -19,9 +19,7 @@ esbuild.toolchain(
 )
 use_repo(esbuild, "esbuild_toolchains")
 
-bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.5.0", dev_dependency = True)
 bazel_dep(name = "buildifier_prebuilt", version = "6.4.0", dev_dependency = True)
-bazel_dep(name = "gazelle", version = "0.35.0", dev_dependency = True, repo_name = "bazel_gazelle")
 bazel_dep(name = "stardoc", version = "0.6.2", dev_dependency = True, repo_name = "io_bazel_stardoc")
 
 register_toolchains("@esbuild_toolchains//:all")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -81,17 +81,6 @@ load("@stardoc_maven//:defs.bzl", stardoc_pinned_maven_install = "pinned_maven_i
 
 stardoc_pinned_maven_install()
 
-############################################
-# Gazelle, for generating bzl_library targets
-load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
-load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
-
-go_rules_dependencies()
-
-go_register_toolchains(version = "1.19.3")
-
-gazelle_dependencies()
-
 # Buildifier
 load("@buildifier_prebuilt//:deps.bzl", "buildifier_prebuilt_deps")
 

--- a/internal_deps.bzl
+++ b/internal_deps.bzl
@@ -19,24 +19,6 @@ def rules_esbuild_internal_deps():
     )
 
     http_archive(
-        name = "io_bazel_rules_go",
-        sha256 = "7c76d6236b28ff695aa28cf35f95de317a9472fd1fb14ac797c9bf684f09b37c",
-        urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.44.2/rules_go-v0.44.2.zip"],
-    )
-
-    http_archive(
-        name = "bazel_gazelle",
-        sha256 = "32938bda16e6700063035479063d9d24c60eda8d79fd4739563f50d331cb3209",
-        urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.35.0/bazel-gazelle-v0.35.0.tar.gz"],
-    )
-
-    http_archive(
-        name = "bazel_skylib_gazelle_plugin",
-        sha256 = "747addf3f508186234f6232674dd7786743efb8c68619aece5fb0cac97b8f415",
-        urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.5.0/bazel-skylib-gazelle-plugin-1.5.0.tar.gz"],
-    )
-
-    http_archive(
         name = "io_bazel_stardoc",
         sha256 = "62bd2e60216b7a6fec3ac79341aa201e0956477e7c8f6ccc286f279ad1d96432",
         urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.6.2/stardoc-0.6.2.tar.gz"],


### PR DESCRIPTION
We don't have any Go sources in rules_esbuild so there's no reason we should install a Go toolchain or worry about upgrading it. 'aspect configure' provides the auto-generation for bzl_library targets so we don't need Gazelle either.
