### PR TITLE
chore: align ci yaml pattern

### DIFF
--- a/.aspect/bazelrc/.gitignore
+++ b/.aspect/bazelrc/.gitignore
@@ -1,0 +1,1 @@
+user.bazelrc

--- a/.bazelignore
+++ b/.bazelignore
@@ -1,1 +1,2 @@
 e2e/
+examples/plugins/node_modules

--- a/.bazelrc
+++ b/.bazelrc
@@ -6,18 +6,7 @@ import %workspace%/.aspect/bazelrc/debug.bazelrc
 import %workspace%/.aspect/bazelrc/javascript.bazelrc
 import %workspace%/.aspect/bazelrc/performance.bazelrc
 
-### YOUR PROJECT SPECIFIC SETTINGS GO HERE ###
-
-# still required for rules_esbuild; work to remove this is in https://github.com/aspect-build/rules_esbuild/pull/177
-common --enable_runfiles
-
-# Disable lockfile for now. It is unstable.
-# https://github.com/bazelbuild/bazel/issues/19026
-# https://github.com/bazelbuild/bazel/issues/19621
-# https://github.com/bazelbuild/bazel/issues/19971
-# https://github.com/bazelbuild/bazel/issues/20272
-# https://github.com/bazelbuild/bazel/issues/20369
-common --lockfile_mode=off
+### YOUR PROJECT SPECIFIC OPTIONS GO HERE ###
 
 # Load any settings specific to the current user.
 # .bazelrc.user should appear in .gitignore so that settings are not shared with team members

--- a/.github/workflows/BUILD.bazel
+++ b/.github/workflows/BUILD.bazel
@@ -1,5 +1,3 @@
-"Aspect bazelrc presets; see https://docs.aspect.build/guides/bazelrc"
-
 load("@aspect_bazel_lib//lib:bazelrc_presets.bzl", "write_aspect_bazelrc_presets")
 
 write_aspect_bazelrc_presets(

--- a/.github/workflows/ci.bazelrc
+++ b/.github/workflows/ci.bazelrc
@@ -2,6 +2,11 @@
 common --disk_cache=~/.cache/bazel-disk-cache
 common --repository_cache=~/.cache/bazel-repository-cache
 
-# Bazel version specific settings
-common:bazel6 --test_tag_filters=-skip-on-bazel6
-common:bazel7 --test_tag_filters=-skip-on-bazel7
+# Debug where options came from
+common --announce_rc
+
+# Allows tests to run bazelisk-in-bazel, since this is the cache folder used
+common --test_env=XDG_CACHE_HOME
+
+# Still required for Windows; work to remove this is in https://github.com/aspect-build/rules_esbuild/pull/177
+common --enable_runfiles

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -89,8 +89,8 @@ jobs:
             ~/.cache/bazel-disk-cache
             ~/.cache/bazel-repository-cache
             ~/.cache/xdg-cache
-          key: bazel-cache-${{ matrix.bazelversion.version }}-${{ matrix.bzlmod }}-${{ matrix.os }}-${{ matrix.folder }}-${{ hashFiles('.bazelrc', '.bazelversion', '.bazeliskrc', '**/BUILD', '**/BUILD.bazel', '**/*.bzl', 'WORKSPACE', 'WORKSPACE.bazel', 'WORKSPACE.bzlmod', 'MODULE.bazel', 'MODULE.bazel.lock') }}
-          restore-keys: bazel-cache-${{ matrix.bazelversion.version }}-${{ matrix.bzlmod }}-${{ matrix.os }}-${{ matrix.folder }}-
+          key: bazel-cache-${{ matrix.bazel-version.version }}-${{ matrix.bzlmod }}-${{ matrix.os }}-${{ matrix.folder }}-${{ hashFiles('.bazelrc', '.bazelversion', '.bazeliskrc', '**/BUILD', '**/BUILD.bazel', '**/*.bzl', 'WORKSPACE', 'WORKSPACE.bazel', 'WORKSPACE.bzlmod', 'MODULE.bazel') }}
+          restore-keys: bazel-cache-${{ matrix.bazel-version.version }}-${{ matrix.bzlmod }}-${{ matrix.os }}-${{ matrix.folder }}-
 
       - name: Configure Bazel version
         working-directory: ${{ matrix.folder }}
@@ -122,7 +122,8 @@ jobs:
             --bazelrc=${GITHUB_WORKSPACE//\\/\/}/.aspect/bazelrc/ci.bazelrc \
             --bazelrc=${GITHUB_WORKSPACE//\\/\/}/.github/workflows/ci.bazelrc \
             test \
-            --config=bazel${{ matrix.bazel-version.major }} \
+            --test_tag_filters=-skip-on-bazel${{ matrix.bazel-version.major }} \
+            --build_tag_filters=-skip-on-bazel${{ matrix.bazel-version.major }} \
             --enable_bzlmod=${{ matrix.bzlmod }} \
             //...
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
             ~/.cache/bazel-disk-cache
             ~/.cache/bazel-repository-cache
             ~/.cache/xdg-cache
-          key: bazel-cache-release-${{ hashFiles('.bazelrc', '.bazelversion', '.bazeliskrc', '**/BUILD', '**/BUILD.bazel', '**/*.bzl', 'WORKSPACE', 'WORKSPACE.bazel', 'WORKSPACE.bzlmod', 'MODULE.bazel', 'MODULE.bazel.lock') }}
+          key: bazel-cache-release-${{ hashFiles('.bazelrc', '.bazelversion', '.bazeliskrc', '**/BUILD', '**/BUILD.bazel', '**/*.bzl', 'WORKSPACE', 'WORKSPACE.bazel', 'WORKSPACE.bzlmod', 'MODULE.bazel') }}
           restore-keys: bazel-cache-release-
 
       - name: bazel test //...

--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,18 @@
 bazel-*
 .bazelrc.user
-node_modules
+node_modules/
+.pnpm-*
+
+.idea/
+.ijwb/
+.vscode
 .DS_Store
 
-# Don't commit lockfile for now as it is unstable. Do allow for it to be
-# created, however, since it gives a performance boost for local development.
-# https://github.com/bazelbuild/bazel/issues/19026
-# https://github.com/bazelbuild/bazel/issues/19621
-# https://github.com/bazelbuild/bazel/issues/19971
-# https://github.com/bazelbuild/bazel/issues/20272
-# https://github.com/bazelbuild/bazel/issues/20369
+# Bazel's MODULE lockfile isn't ready to check in yet as of Bazel 7.1.
+# Do allow for it to be created, however, since it gives a performance boost for local development.
+# [Store resolved repository attributes in the Bzlmod lockfile](https://github.com/bazelbuild/bazel/issues/19026)
+# [MODULE.bazel.lock file contains user specific paths](https://github.com/bazelbuild/bazel/issues/19621)
+# [Consider skipping bazel_tools@_ from lockfile](https://github.com/bazelbuild/bazel/issues/19971)
+# [MODULE.bazel.lock file "reads through" already-locked package manager](https://github.com/bazelbuild/bazel/issues/20272)
+# [moduleFileHash in MODULE.bazel.lock causes frequent Git merge conflicts](https://github.com/bazelbuild/bazel/issues/20369)
 MODULE.bazel.lock

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,4 @@
+# Disabling pnpm [hoisting](https://pnpm.io/npmrc#hoist) by setting `hoist=false` is recommended on
+# projects using rules_js so that pnpm outside of Bazel lays out a node_modules tree similar to what
+# rules_js lays out under Bazel (without a hidden node_modules/.pnpm/node_modules)
+hoist=false

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -48,7 +48,9 @@ load("@aspect_rules_js//npm:npm_import.bzl", "npm_translate_lock")
 
 npm_translate_lock(
     name = "esbuild_plugins",
+    npmrc = "//:.npmrc",
     pnpm_lock = "//examples/plugins:pnpm-lock.yaml",
+    verify_node_modules_ignored = "//:.bazelignore",
 )
 
 load("@esbuild_plugins//:repositories.bzl", _esbuild_plugin_repositories = "npm_repositories")

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -14,6 +14,5 @@ stardoc_with_diff_test(
 
 update_docs(
     name = "update",
-    # slight docs different in Bazel 6 for default value of esbuild_bundle.output_map breaks this test
-    tags = ["skip-on-bazel6"],
+    tags = ["skip-on-bazel6"],  # slight docs difference in Bazel 6
 )

--- a/e2e/bundle/.bazelrc
+++ b/e2e/bundle/.bazelrc
@@ -1,2 +1,15 @@
-build --enable_runfiles
-common:bzlmod --enable_bzlmod
+# Import Aspect bazelrc presets
+try-import %workspace%/../../.aspect/bazelrc/bazel7.bazelrc
+import %workspace%/../../.aspect/bazelrc/convenience.bazelrc
+import %workspace%/../../.aspect/bazelrc/correctness.bazelrc
+import %workspace%/../../.aspect/bazelrc/debug.bazelrc
+import %workspace%/../../.aspect/bazelrc/javascript.bazelrc
+import %workspace%/../../.aspect/bazelrc/performance.bazelrc
+
+### YOUR PROJECT SPECIFIC OPTIONS GO HERE ###
+
+# Load any settings & overrides specific to the current user from `.aspect/bazelrc/user.bazelrc`.
+# This file should appear in `.gitignore` so that settings are not shared with team members. This
+# should be last statement in this config so the user configuration is able to overwrite flags from
+# this file. See https://bazel.build/configure/best-practices#bazelrc-file.
+try-import %workspace%/../../.aspect/bazelrc/user.bazelrc

--- a/e2e/bundle/.bazelversion
+++ b/e2e/bundle/.bazelversion
@@ -1,0 +1,1 @@
+../../.bazelversion

--- a/e2e/bundle/.npmrc
+++ b/e2e/bundle/.npmrc
@@ -1,0 +1,4 @@
+# Disabling pnpm [hoisting](https://pnpm.io/npmrc#hoist) by setting `hoist=false` is recommended on
+# projects using rules_js so that pnpm outside of Bazel lays out a node_modules tree similar to what
+# rules_js lays out under Bazel (without a hidden node_modules/.pnpm/node_modules)
+hoist=false

--- a/e2e/npm-links/.bazelignore
+++ b/e2e/npm-links/.bazelignore
@@ -1,0 +1,1 @@
+node_modules

--- a/e2e/npm-links/.bazelrc
+++ b/e2e/npm-links/.bazelrc
@@ -1,2 +1,15 @@
-build --enable_runfiles
-common:bzlmod --enable_bzlmod
+# Import Aspect bazelrc presets
+try-import %workspace%/../../.aspect/bazelrc/bazel7.bazelrc
+import %workspace%/../../.aspect/bazelrc/convenience.bazelrc
+import %workspace%/../../.aspect/bazelrc/correctness.bazelrc
+import %workspace%/../../.aspect/bazelrc/debug.bazelrc
+import %workspace%/../../.aspect/bazelrc/javascript.bazelrc
+import %workspace%/../../.aspect/bazelrc/performance.bazelrc
+
+### YOUR PROJECT SPECIFIC OPTIONS GO HERE ###
+
+# Load any settings & overrides specific to the current user from `.aspect/bazelrc/user.bazelrc`.
+# This file should appear in `.gitignore` so that settings are not shared with team members. This
+# should be last statement in this config so the user configuration is able to overwrite flags from
+# this file. See https://bazel.build/configure/best-practices#bazelrc-file.
+try-import %workspace%/../../.aspect/bazelrc/user.bazelrc

--- a/e2e/npm-links/.npmrc
+++ b/e2e/npm-links/.npmrc
@@ -1,0 +1,4 @@
+# Disabling pnpm [hoisting](https://pnpm.io/npmrc#hoist) by setting `hoist=false` is recommended on
+# projects using rules_js so that pnpm outside of Bazel lays out a node_modules tree similar to what
+# rules_js lays out under Bazel (without a hidden node_modules/.pnpm/node_modules)
+hoist=false

--- a/e2e/npm-links/MODULE.bazel
+++ b/e2e/npm-links/MODULE.bazel
@@ -10,6 +10,8 @@ bazel_dep(name = "bazel_skylib", version = "1.5.0", dev_dependency = True)
 npm = use_extension("@aspect_rules_js//npm:extensions.bzl", "npm", dev_dependency = True)
 npm.npm_translate_lock(
     name = "npm",
+    npmrc = "//:.npmrc",
     pnpm_lock = "//:pnpm-lock.yaml",
+    verify_node_modules_ignored = "//:.bazelignore",
 )
 use_repo(npm, "npm")

--- a/e2e/npm-links/WORKSPACE
+++ b/e2e/npm-links/WORKSPACE
@@ -28,7 +28,9 @@ load("@aspect_rules_js//npm:npm_import.bzl", "npm_translate_lock")
 
 npm_translate_lock(
     name = "npm",
+    npmrc = "//:.npmrc",
     pnpm_lock = "//:pnpm-lock.yaml",
+    verify_node_modules_ignored = "//:.bazelignore",
 )
 
 # Register a toolchain containing esbuild npm package and native bindings

--- a/e2e/smoke/.bazelrc
+++ b/e2e/smoke/.bazelrc
@@ -1,2 +1,15 @@
-build --enable_runfiles
-common:bzlmod --enable_bzlmod
+# Import Aspect bazelrc presets
+try-import %workspace%/../../.aspect/bazelrc/bazel7.bazelrc
+import %workspace%/../../.aspect/bazelrc/convenience.bazelrc
+import %workspace%/../../.aspect/bazelrc/correctness.bazelrc
+import %workspace%/../../.aspect/bazelrc/debug.bazelrc
+import %workspace%/../../.aspect/bazelrc/javascript.bazelrc
+import %workspace%/../../.aspect/bazelrc/performance.bazelrc
+
+### YOUR PROJECT SPECIFIC OPTIONS GO HERE ###
+
+# Load any settings & overrides specific to the current user from `.aspect/bazelrc/user.bazelrc`.
+# This file should appear in `.gitignore` so that settings are not shared with team members. This
+# should be last statement in this config so the user configuration is able to overwrite flags from
+# this file. See https://bazel.build/configure/best-practices#bazelrc-file.
+try-import %workspace%/../../.aspect/bazelrc/user.bazelrc

--- a/e2e/smoke/.npmrc
+++ b/e2e/smoke/.npmrc
@@ -1,0 +1,4 @@
+# Disabling pnpm [hoisting](https://pnpm.io/npmrc#hoist) by setting `hoist=false` is recommended on
+# projects using rules_js so that pnpm outside of Bazel lays out a node_modules tree similar to what
+# rules_js lays out under Bazel (without a hidden node_modules/.pnpm/node_modules)
+hoist=false

--- a/e2e/sourcemaps/.bazelrc
+++ b/e2e/sourcemaps/.bazelrc
@@ -1,2 +1,15 @@
-build --enable_runfiles
-common:bzlmod --enable_bzlmod
+# Import Aspect bazelrc presets
+try-import %workspace%/../../.aspect/bazelrc/bazel7.bazelrc
+import %workspace%/../../.aspect/bazelrc/convenience.bazelrc
+import %workspace%/../../.aspect/bazelrc/correctness.bazelrc
+import %workspace%/../../.aspect/bazelrc/debug.bazelrc
+import %workspace%/../../.aspect/bazelrc/javascript.bazelrc
+import %workspace%/../../.aspect/bazelrc/performance.bazelrc
+
+### YOUR PROJECT SPECIFIC OPTIONS GO HERE ###
+
+# Load any settings & overrides specific to the current user from `.aspect/bazelrc/user.bazelrc`.
+# This file should appear in `.gitignore` so that settings are not shared with team members. This
+# should be last statement in this config so the user configuration is able to overwrite flags from
+# this file. See https://bazel.build/configure/best-practices#bazelrc-file.
+try-import %workspace%/../../.aspect/bazelrc/user.bazelrc

--- a/e2e/sourcemaps/.bazelversion
+++ b/e2e/sourcemaps/.bazelversion
@@ -1,0 +1,1 @@
+../../.bazelversion

--- a/e2e/sourcemaps/.npmrc
+++ b/e2e/sourcemaps/.npmrc
@@ -1,0 +1,4 @@
+# Disabling pnpm [hoisting](https://pnpm.io/npmrc#hoist) by setting `hoist=false` is recommended on
+# projects using rules_js so that pnpm outside of Bazel lays out a node_modules tree similar to what
+# rules_js lays out under Bazel (without a hidden node_modules/.pnpm/node_modules)
+hoist=false

--- a/e2e/tsconfig/.bazelrc
+++ b/e2e/tsconfig/.bazelrc
@@ -1,2 +1,15 @@
-build --enable_runfiles
-common:bzlmod --enable_bzlmod
+# Import Aspect bazelrc presets
+try-import %workspace%/../../.aspect/bazelrc/bazel7.bazelrc
+import %workspace%/../../.aspect/bazelrc/convenience.bazelrc
+import %workspace%/../../.aspect/bazelrc/correctness.bazelrc
+import %workspace%/../../.aspect/bazelrc/debug.bazelrc
+import %workspace%/../../.aspect/bazelrc/javascript.bazelrc
+import %workspace%/../../.aspect/bazelrc/performance.bazelrc
+
+### YOUR PROJECT SPECIFIC OPTIONS GO HERE ###
+
+# Load any settings & overrides specific to the current user from `.aspect/bazelrc/user.bazelrc`.
+# This file should appear in `.gitignore` so that settings are not shared with team members. This
+# should be last statement in this config so the user configuration is able to overwrite flags from
+# this file. See https://bazel.build/configure/best-practices#bazelrc-file.
+try-import %workspace%/../../.aspect/bazelrc/user.bazelrc

--- a/e2e/tsconfig/.npmrc
+++ b/e2e/tsconfig/.npmrc
@@ -1,0 +1,4 @@
+# Disabling pnpm [hoisting](https://pnpm.io/npmrc#hoist) by setting `hoist=false` is recommended on
+# projects using rules_js so that pnpm outside of Bazel lays out a node_modules tree similar to what
+# rules_js lays out under Bazel (without a hidden node_modules/.pnpm/node_modules)
+hoist=false


### PR DESCRIPTION
Lots of cleanup of our CI and bazelrc patterns here. Aligns these patterns with the other rules_js rulesets. No functional changes.