### PR TITLE
fix: remove module cache in sandbox plugin

### DIFF
--- a/esbuild/private/plugins/bazel-sandbox.js
+++ b/esbuild/private/plugins/bazel-sandbox.js
@@ -1,9 +1,6 @@
 const path = require('path')
 const process = require('process')
 
-// Regex matching any non-relative import path
-const pkgImport = /^[^.]/
-
 const bindir = process.env.BAZEL_BINDIR
 const execroot = process.env.JS_BINARY__EXECROOT
 
@@ -14,7 +11,6 @@ function bazelSandboxPlugin() {
   return {
     name: 'bazel-sandbox',
     setup(build) {
-      const moduleCache = new Map()
       build.onResolve(
         { filter: /./ },
         async ({ path: importPath, ...otherOptions }) => {
@@ -28,16 +24,6 @@ function bazelSandboxPlugin() {
           }
           otherOptions.pluginData.executedSandboxPlugin = true
 
-          // Prevent us from loading different forms of a module (CJS vs ESM).
-          if (pkgImport.test(importPath)) {
-            if (!moduleCache.has(importPath)) {
-              moduleCache.set(
-                importPath,
-                resolveInExecroot(build, importPath, otherOptions)
-              )
-            }
-            return await moduleCache.get(importPath)
-          }
           return await resolveInExecroot(build, importPath, otherOptions)
         }
       )


### PR DESCRIPTION
This module cache came up as problematic with the presence of multiple versions of a package in a given dependency closure. In our case, we have `minipass` 4.2.8 and 7.0.4 (required by `glob` 9.3.2 and `path-scurry` 1.10.1 respectively) in a given closure. These are strictly not compatible with each other, so resolving `minipass` from `glob` should yield 4.2.8 and from `path-scurry` should yield 7.0.4. The module cache however results in everything getting the same version, as we are keying only by name sans version.

Log output I added to illustrate the point:
```
DEBUG NOAH BEGIN: 
        IMPORTER /home/noah/.cache/bazel/_bazel_noah/8fd1d20666a46767e7f29541678514a0/sandbox/linux-sandbox/10/execroot/__main__/bazel-out/k8-fastbuild/bin/node_modules/.aspect_rules_js/glob@9.3.2/node_modules/glob/dist/mjs/walker.js
DEBUG NOAH RETURN RESOLVE: 
        IMPORTER /home/noah/.cache/bazel/_bazel_noah/8fd1d20666a46767e7f29541678514a0/sandbox/linux-sandbox/10/execroot/__main__/bazel-out/k8-fastbuild/bin/node_modules/.aspect_rules_js/glob@9.3.2/node_modules/glob/dist/mjs/walker.js
        RESOLVED /home/noah/.cache/bazel/_bazel_noah/8fd1d20666a46767e7f29541678514a0/sandbox/linux-sandbox/10/execroot/__main__/bazel-out/k8-fastbuild/bin/node_modules/.aspect_rules_js/minipass@4.2.8/node_modules/minipass/index.mjs
DEBUG NOAH BEGIN: 
        IMPORTER /home/noah/.cache/bazel/_bazel_noah/8fd1d20666a46767e7f29541678514a0/sandbox/linux-sandbox/10/execroot/__main__/bazel-out/k8-fastbuild/bin/node_modules/.aspect_rules_js/path-scurry@1.10.1/node_modules/path-scurry/dist/mjs/index.js
DEBUG NOAH RETURN WOULD-BE CACHE: 
        IMPORTER /home/noah/.cache/bazel/_bazel_noah/8fd1d20666a46767e7f29541678514a0/sandbox/linux-sandbox/10/execroot/__main__/bazel-out/k8-fastbuild/bin/node_modules/.aspect_rules_js/path-scurry@1.10.1/node_modules/path-scurry/dist/mjs/index.js
        RESOLVED /home/noah/.cache/bazel/_bazel_noah/8fd1d20666a46767e7f29541678514a0/sandbox/linux-sandbox/10/execroot/__main__/bazel-out/k8-fastbuild/bin/node_modules/.aspect_rules_js/minipass@4.2.8/node_modules/minipass/index.mjs
DEBUG NOAH RETURN RESOLVE: 
        IMPORTER /home/noah/.cache/bazel/_bazel_noah/8fd1d20666a46767e7f29541678514a0/sandbox/linux-sandbox/10/execroot/__main__/bazel-out/k8-fastbuild/bin/node_modules/.aspect_rules_js/path-scurry@1.10.1/node_modules/path-scurry/dist/mjs/index.js
        RESOLVED /home/noah/.cache/bazel/_bazel_noah/8fd1d20666a46767e7f29541678514a0/sandbox/linux-sandbox/10/execroot/__main__/bazel-out/k8-fastbuild/bin/node_modules/.aspect_rules_js/minipass@7.0.4/node_modules/minipass/dist/esm/index.js
```

from the following diff to 0.19.0:
```diff
diff --git a/esbuild/private/plugins/bazel-sandbox.js b/esbuild/private/plugins/bazel-sandbox.js
index 84f0921..32ccaa7 100644
--- a/esbuild/private/plugins/bazel-sandbox.js
+++ b/esbuild/private/plugins/bazel-sandbox.js
@@ -28,15 +28,27 @@ function bazelSandboxPlugin() {
           }
           otherOptions.pluginData.executedSandboxPlugin = true
 
+          if (importPath === 'minipass') {
+            console.error(`DEBUG NOAH BEGIN: \n\tIMPORTER ${otherOptions.importer}`)
+          }
+
           // Prevent us from loading different forms of a module (CJS vs ESM).
           if (pkgImport.test(importPath)) {
-            if (!moduleCache.has(importPath)) {
+            const isNotCached = !moduleCache.has(importPath)
+            if (isNotCached) {
               moduleCache.set(
                 importPath,
                 resolveInExecroot(build, importPath, otherOptions)
               )
             }
-            return await moduleCache.get(importPath)
+            const res = await moduleCache.get(importPath)
+            if (importPath === 'minipass' && !isNotCached) {
+              console.error(`DEBUG NOAH RETURN WOULD-BE CACHE: \n\tIMPORTER ${otherOptions.importer}\n\tRESOLVED ${res.path}`)
+            }
+            // only for log output clarity
+            if (isNotCached) {
+              return res
+            }
           }
           return await resolveInExecroot(build, importPath, otherOptions)
         }
@@ -62,6 +74,14 @@ async function resolveInExecroot(build, importPath, otherOptions) {
     return result
   }
 
+  const res = correctImportPath(result, otherOptions, false)
+  if (importPath ==='minipass') {
+    console.error(`DEBUG NOAH RETURN RESOLVE: \n\tIMPORTER ${otherOptions.importer}\n\tRESOLVED ${res.path}`)
+  }
+  return res
+}
+
+function correctImportPath(result, otherOptions, firstEntry) {
   // If esbuild attempts to leave the execroot, map the path back into the execroot.
   if (!result.path.startsWith(execroot)) {
     // If it tried to leave bazel-bin, error out completely.

```

The one thing Im unsure about is the comment about avoiding loading both ESM and CJS, Im not sure if theres an easy reproducer somewhere or a test case in this repo that covers it cc @vpanta 

---

### Test plan

- Manual testing; please provide instructions so we can reproduce:

This issue was being worked on as part of a series of issues that cropped up when upgrading to 0.19.0, including https://github.com/aspect-build/rules_esbuild/pull/201. As such, the manual testing I did was the same as mentioned over there, except for a different commit: github.com/sourcegraph/sourcegraph/commit/51503969643612665485aa8e6e150566b6863d54 with target `//client/web/dev:esbuild-config-production_bundle`