### PR TITLE
always set 'use_default_shell_env' in ctx.actions.run

### DIFF
--- a/esbuild/private/esbuild.bzl
+++ b/esbuild/private/esbuild.bzl
@@ -391,6 +391,7 @@ def _esbuild_impl(ctx):
         execution_requirements = execution_requirements,
         mnemonic = "esbuild",
         env = env,
+        use_default_shell_env = True,
         executable = launcher,
     )
 


### PR DESCRIPTION
Aspect uses shell wrappers that invoke tools like `dirname` and `uname`. When the default shell env is not inherited, this prevents tools from being found on systems without a working fallback $PATH (like NixOS).

This might be incompatible with setting the env attribute, unless the bazel flag --incompatible_merge_fixed_and_default_shell_env is set on Bazel versions < 7.

See also: NixOS/nixpkgs#289505

---

### Changes are visible to end-users: no

### Test plan

<!-- Delete any which do not apply -->

- Covered by existing test cases
