### PR TITLE
fix: remove deprecated incompatible_use_toolchain_transition flag

### DIFF
--- a/esbuild/private/resolved_toolchain.bzl
+++ b/esbuild/private/resolved_toolchain.bzl
@@ -22,5 +22,4 @@ def _resolved_toolchain_impl(ctx):
 resolved_toolchain = rule(
     implementation = _resolved_toolchain_impl,
     toolchains = ["@aspect_rules_esbuild//esbuild:toolchain_type"],
-    incompatible_use_toolchain_transition = True,
 )


### PR DESCRIPTION
Bazel recently completely killed this flag in bazelbuild/bazel@f53608ac3dbfd02cecb4bb78a138badb0d84e311.
