### PR TITLE
feat: implement esbuild(out_dirs) to support features such as esbuild asset dirs

### DIFF
--- a/esbuild/private/esbuild.bzl
+++ b/esbuild/private/esbuild.bzl
@@ -111,6 +111,18 @@ If your JS code contains import statements that import .css files, esbuild will 
 content in a file next to the main output file, which you'll need to declare. If your output
 file is named 'foo.js', you should set this to 'foo.css'.""",
     ),
+    "out_dirs": attr.string_list(
+        default = [],
+        doc = """Additional output directories to declare for this target.
+
+Use this when your esbuild config causes outputs to be written into subdirectories,
+for example when setting assetNames to a path like "assets/[name]-[hash]".
+Bazel requires all action outputs to be declared upfront; each entry becomes a
+declared directory (TreeArtifact) in the rule's DefaultInfo outputs.
+
+Each name is relative to the rule's output location, e.g. "assets".
+""",
+    ),
     "output_dir": attr.bool(
         default = False,
         doc = """If true, esbuild produces an output directory containing all output files""",
@@ -276,6 +288,9 @@ def _esbuild_impl(ctx):
         # disable this unless also minifying
         args.update({"ignoreAnnotations": True})
 
+    if ctx.attr.out_dirs and ctx.attr.output_dir:
+        fail("out_dirs is not needed when output_dir = True; esbuild's output directory already captures all files")
+
     if ctx.attr.splitting:
         if not ctx.attr.output_dir:
             fail("output_dir must be set to True when splitting is set to True")
@@ -314,6 +329,10 @@ def _esbuild_impl(ctx):
             output_sources.append(ctx.outputs.output_css)
 
         args.update({"outfile": _bin_relative_path(ctx, js_out)})
+
+    for dir_name in ctx.attr.out_dirs:
+        extra_dir = ctx.actions.declare_directory(dir_name)
+        output_sources.append(extra_dir)
 
     env = {
         "BAZEL_BINDIR": ctx.bin_dir.path,

--- a/esbuild/private/esbuild.bzl
+++ b/esbuild/private/esbuild.bzl
@@ -111,6 +111,21 @@ If your JS code contains import statements that import .css files, esbuild will 
 content in a file next to the main output file, which you'll need to declare. If your output
 file is named 'foo.js', you should set this to 'foo.css'.""",
     ),
+    "out_dirs": attr.string_list(
+        default = [],
+        doc = """Additional output directories to declare for this target.
+
+Use this when your esbuild config causes outputs to be written into subdirectories,
+for example when setting assetNames to a path like "assets/[name]-[hash]".
+Bazel requires all action outputs to be declared upfront; each entry becomes a
+declared directory (TreeArtifact) in the rule's DefaultInfo outputs.
+
+Each entry is a path relative to the package, e.g. "assets". When the rule's
+`output` is set to a nested path such as "dist/bundle.js", the entry must
+include the same prefix (e.g. "dist/assets") because esbuild writes asset
+files relative to the directory of `outfile`.
+""",
+    ),
     "output_dir": attr.bool(
         default = False,
         doc = """If true, esbuild produces an output directory containing all output files""",
@@ -276,6 +291,9 @@ def _esbuild_impl(ctx):
         # disable this unless also minifying
         args.update({"ignoreAnnotations": True})
 
+    if ctx.attr.out_dirs and ctx.attr.output_dir:
+        fail("out_dirs is not needed when output_dir = True; esbuild's output directory already captures all files")
+
     if ctx.attr.splitting:
         if not ctx.attr.output_dir:
             fail("output_dir must be set to True when splitting is set to True")
@@ -314,6 +332,10 @@ def _esbuild_impl(ctx):
             output_sources.append(ctx.outputs.output_css)
 
         args.update({"outfile": _bin_relative_path(ctx, js_out)})
+
+    for dir_name in ctx.attr.out_dirs:
+        extra_dir = ctx.actions.declare_directory(dir_name)
+        output_sources.append(extra_dir)
 
     env = {
         "BAZEL_BINDIR": ctx.bin_dir.path,

--- a/examples/asserts.bzl
+++ b/examples/asserts.bzl
@@ -3,28 +3,49 @@
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
 
-def assert_contains(name, actual, expected):
-    """Generates a test target which fails if the file doesn't contain the string.
+def assert_contains(name, actual, expected, file = None):
+    """Generates a test target which fails if a file doesn't contain the string.
 
     Args:
         name: target to create
-        actual: a file
+        actual: a file label, or (when `file` is set) a target whose runfiles contain `file`
         expected: a string which should appear in the file
+        file: optional path within `actual`'s runfiles to search instead of `actual` itself.
+            Use this to assert on a file inside a TreeArtifact output.
     """
 
-    write_file(
-        name = "_" + name,
-        out = "test.sh",
-        content = [
+    if file:
+        script = [
+            "#!/usr/bin/env bash",
+            "set -o errexit",
+            "root=\"${TEST_SRCDIR:-$RUNFILES_DIR}\"",
+            "found=$(find \"$root\" -path '*/%s' -print -quit)" % file,
+            "if [ -z \"$found\" ]; then",
+            "  echo \"expected file '%s' not found in runfiles ($root)\" >&2" % file,
+            "  echo \"contents:\" >&2",
+            "  find \"$root\" >&2 || true",
+            "  exit 1",
+            "fi",
+            "grep --fixed-strings '%s' \"$found\"" % expected,
+        ]
+        args = []
+    else:
+        script = [
             "#!/usr/bin/env bash",
             "set -o errexit",
             "grep --fixed-strings '%s' $1" % expected,
-        ],
+        ]
+        args = ["$(rootpath %s)" % actual]
+
+    write_file(
+        name = "_" + name,
+        out = name + "_test.sh",
+        content = script,
     )
 
     sh_test(
         name = name,
-        srcs = ["test.sh"],
-        args = ["$(rootpath %s)" % actual],
+        srcs = [name + "_test.sh"],
+        args = args,
         data = [actual],
     )

--- a/examples/asset_names/BUILD.bazel
+++ b/examples/asset_names/BUILD.bazel
@@ -1,0 +1,72 @@
+"Example demonstrating assetNames support via esbuild config and out_dirs"
+
+load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load("//examples:asserts.bzl", "assert_contains")
+
+# Uses a config dict to set assetNames and loader (esbuild options not exposed
+# as direct rule attributes). out_dirs declares the extra output directory that
+# esbuild will write assets into, so Bazel can track it as an output.
+esbuild(
+    name = "bundle",
+    srcs = ["src/logo.png"],
+    config = {
+        "assetNames": "assets/[name]",
+        "loader": {".png": "file"},
+    },
+    entry_point = "src/index.js",
+    out_dirs = ["assets"],
+)
+
+# Verify the bundle JS references the asset path produced by assetNames.
+assert_contains(
+    name = "test",
+    actual = ":bundle.js",
+    expected = "assets/logo",
+)
+
+# Verify esbuild's emitted asset is captured at the declared TreeArtifact path.
+assert_contains(
+    name = "asset_test",
+    actual = ":bundle",
+    expected = "placeholder png content",
+    file = "examples/asset_names/assets/logo.png",
+)
+
+# When the bundle output is in a nested directory, esbuild writes asset files
+# next to the bundle (i.e. under that nested directory). out_dirs entries must
+# include the same prefix so Bazel can capture them.
+esbuild(
+    name = "nested_bundle",
+    srcs = ["src/logo.png"],
+    config = {
+        "assetNames": "assets/[name]",
+        "loader": {".png": "file"},
+    },
+    entry_point = "src/index.js",
+    out_dirs = ["nested/assets"],
+    output = "nested/nested_bundle.js",
+)
+
+# Verify the bundle JS references the asset path produced by assetNames.
+assert_contains(
+    name = "nested_bundle_js_test",
+    actual = ":nested/nested_bundle.js",
+    expected = "assets/logo",
+)
+
+# Verify esbuild's emitted asset is captured at the declared TreeArtifact path.
+assert_contains(
+    name = "nested_asset_test",
+    actual = ":nested_bundle",
+    expected = "placeholder png content",
+    file = "examples/asset_names/nested/assets/logo.png",
+)
+
+build_test(
+    name = "build_test",
+    targets = [
+        ":bundle",
+        ":nested_bundle",
+    ],
+)

--- a/examples/asset_names/BUILD.bazel
+++ b/examples/asset_names/BUILD.bazel
@@ -1,0 +1,31 @@
+"Example demonstrating assetNames support via esbuild config and out_dirs"
+
+load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load("//examples:asserts.bzl", "assert_contains")
+
+# Uses a config dict to set assetNames and loader (esbuild options not exposed
+# as direct rule attributes). out_dirs declares the extra output directory that
+# esbuild will write assets into, so Bazel can track it as an output.
+esbuild(
+    name = "bundle",
+    srcs = ["src/logo.png"],
+    config = {
+        "assetNames": "assets/[name]",
+        "loader": {".png": "file"},
+    },
+    entry_point = "src/index.js",
+    out_dirs = ["assets"],
+)
+
+# Verify the bundle JS references the asset path produced by assetNames
+assert_contains(
+    name = "test",
+    actual = ":bundle.js",
+    expected = "assets/logo",
+)
+
+build_test(
+    name = "build_test",
+    targets = [":bundle"],
+)

--- a/examples/asset_names/src/index.js
+++ b/examples/asset_names/src/index.js
@@ -1,0 +1,2 @@
+import logoUrl from "./logo.png"
+console.log(logoUrl)

--- a/examples/asset_names/src/logo.png
+++ b/examples/asset_names/src/logo.png
@@ -1,0 +1,1 @@
+placeholder png content for esbuild file loader test


### PR DESCRIPTION
Close #124

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Add `esbuild(out_dirs)` for declaring additional output directories such as when suing the esbuild [assetNames](https://esbuild.github.io/api/#asset-names)

### Test plan

- Covered by existing test cases
- New test cases added
