### PR TITLE
fix: make esbuild action explicit about toolchains

### DIFF
--- a/esbuild/private/esbuild.bzl
+++ b/esbuild/private/esbuild.bzl
@@ -417,6 +417,7 @@ def _esbuild_impl(ctx):
         env = env,
         use_default_shell_env = True,
         executable = launcher,
+        toolchain = None,
     )
 
     output_sources_depset = depset(output_sources)


### PR DESCRIPTION
The --incompatible_auto_exec_groups flag requires Starlark actions to declare whether their executable/tools come from an action toolchain. This is not a Bazel default today, but it is exposed through strict preset configurations and is intended to catch rules that rely on implicit action toolchain inference.

The esbuild action can run either a launcher selected from the esbuild toolchain or an explicit launcher attribute. Mark the action with toolchain = None so its action toolchain behavior is explicit without changing its inputs or execution model.

### Test plan

- Manual testing; please provide instructions so we can reproduce: Using this patch on rules_js in our repository with --incompatible_auto_exec_groups everything starts to work.