### PR TITLE
feat: expose esbuild metafile via OutputGroupInfo

### DIFF
--- a/esbuild/private/esbuild.bzl
+++ b/esbuild/private/esbuild.bzl
@@ -364,11 +364,13 @@ def _esbuild_impl(ctx):
     other_inputs.append(args_file)
     launcher_args.add("--esbuild_args=%s" % _bin_relative_path(ctx, args_file))
 
+    output_groups = {}
     if ctx.attr.metafile:
         # add metafile
         meta_file = ctx.actions.declare_file("%s_metadata.json" % ctx.attr.name)
         output_sources.append(meta_file)
         launcher_args.add("--metafile=%s" % _bin_relative_path(ctx, meta_file))
+        output_groups["metafile"] = depset([meta_file])
 
     # add reference to the users args file, these are merged within the launcher
     if ctx.attr.args_file:
@@ -481,6 +483,7 @@ def _esbuild_impl(ctx):
             npm_sources = npm_sources,
             npm_package_store_infos = npm_package_store_infos,
         ),
+        OutputGroupInfo(**output_groups),
     ]
 
 lib = struct(

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
+load(":asserts.bzl", "assert_contains")
 
 esbuild(
     name = "lib",
@@ -18,6 +19,30 @@ esbuild(
 build_test(
     name = "test",
     targets = [":lib"],
+)
+
+filegroup(
+    name = "lib_metafile",
+    srcs = [":lib"],
+    output_group = "metafile",
+)
+
+assert_contains(
+    name = "metafile_has_inputs_test",
+    actual = ":lib_metafile",
+    expected = '"inputs":{',
+)
+
+assert_contains(
+    name = "metafile_has_outputs_test",
+    actual = ":lib_metafile",
+    expected = '"outputs":{',
+)
+
+assert_contains(
+    name = "metafile_references_main_test",
+    actual = ":lib_metafile",
+    expected = "examples/main.js",
 )
 
 sh_test(


### PR DESCRIPTION
Currently, when `metafile = True` is provided to `esbuild`, the generated metadata JSON file is only made available through `DefaultInfo`. This forces downstream consuming rules that to iterate through all default outputs and select the metadata file heuristically (e.g. `f.basename.endswith("_metadata.json")`).

This change exposes the metafile through `OutputGroupInfo(...)`, enabling downstream consumers and `filegroup` targets to reference the metafile directly using `output_group = "metafile"`.

---

### Changes are visible to end-users: yes/no

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Expose esbuild metafile via `OutputGroupInfo` "metafile"

### Test plan

- New test cases added